### PR TITLE
normalized_mutations as argument instead of class field

### DIFF
--- a/src/models/signature_finder.py
+++ b/src/models/signature_finder.py
@@ -29,19 +29,19 @@ class SignatureFinder:
             return np.sum(w) - 1
         self.constraints = [{"type": "eq", "fun": constrain}]
 
-    def __objective(self, w):
+    def __objective(self, w, normalized_mutations):
         with torch.no_grad():
             guess = np.dot(self.signatures, w)
             guess_tensor = torch.from_numpy(guess).unsqueeze(0)
-            error = self.metric(guess_tensor, self.normalized_mutations)
+            error = self.metric(guess_tensor, normalized_mutations)
         return error.numpy() + self.lagrange_mult*(np.sum(w) - 1)**2
 
     def get_weights(self, normalized_mutations):
         w = np.random.uniform(low=0, high=1, size=(self.__weight_len,))
-        self.normalized_mutations = torch.from_numpy(
-            np.array(normalized_mutations)).unsqueeze(0)
+        normalized_mutations = torch.from_numpy(np.array(normalized_mutations)).unsqueeze(0)
         res = minimize(fun=self.__objective,
                        x0=w,
+                       args=(normalized_mutations,),
                        bounds=self.__bounds)
         return res.x
 

--- a/src/utilities/metrics.py
+++ b/src/utilities/metrics.py
@@ -45,11 +45,10 @@ def get_kl_divergence(predicted_label, true_label):
 
 
 def get_jensen_shannon(predicted_label, true_label):
-    true_label_local = copy.deepcopy(true_label)
-    true_label_local += 1e-6
-    r = (predicted_label + true_label_local)/2
-    term1 = torch.mean(torch.einsum("ij,ij->i",(predicted_label,torch.log(torch.div(predicted_label, r)))))
-    term2 = torch.mean(torch.einsum("ij,ij->i",(true_label_local, torch.log(torch.div(true_label_local, r)))))
+    _EPS = 1e-6
+    r = (predicted_label + true_label)/2 + _EPS
+    term1 = torch.mean(torch.einsum("ij,ij->i",(predicted_label, torch.log(torch.div(predicted_label + _EPS, r)))))
+    term2 = torch.mean(torch.einsum("ij,ij->i",(true_label, torch.log(torch.div(true_label + _EPS, r)))))
     return 0.5 * (term1 + term2) 
 
 


### PR DESCRIPTION
I think the problem was:

We were saving `self.normalized_mutations` as a class field, but when running the multiprocessing code this field got overwritten all the time. I fixed it by passing it as an argument of the optimization function as we had at the beginning. I don't remember why we changed it (maybe em vaig flipar una mica amb el refactor), but I think now its ok.

I havent had time to run it, let me know if everything is ok